### PR TITLE
fix: reversed wtime and btime reporting

### DIFF
--- a/internal/arbiter/cmd/root.go
+++ b/internal/arbiter/cmd/root.go
@@ -40,7 +40,7 @@ func Root() *cobra.Command {
 	root.PersistentFlags().BoolP("trace", "t", false, "Show Trace Information")
 
 	// TODO: properly set version
-	versionStr := "v0.2.1\n"
+	versionStr := "v0.2.2\n"
 	root.SetVersionTemplate(versionStr)
 	root.Version = versionStr
 

--- a/pkg/eve/match/games/ataxx.go
+++ b/pkg/eve/match/games/ataxx.go
@@ -17,7 +17,7 @@ func (oracle *AtaxxOracle) Initialize(fenstr string) {
 }
 
 func (oracle *AtaxxOracle) SideToMove() Color {
-	return Color(oracle.position.turn)
+	return Color(1 - oracle.position.turn)
 }
 
 func (oracle *AtaxxOracle) MakeMove(movstr string) error {


### PR DESCRIPTION
<samp> This one is on me, sorry people.
Fixed the bug where black's time is reported as wtime and white's as btime lmao </samp>